### PR TITLE
CanvasTinter is a plain object, not a class.

### DIFF
--- a/src/core/renderers/canvas/utils/CanvasTinter.js
+++ b/src/core/renderers/canvas/utils/CanvasTinter.js
@@ -2,9 +2,7 @@ var utils = require('../../../utils');
 
 /**
  * Utility methods for Sprite/Texture tinting.
- * @static
- * @class
- * @memberof PIXI
+ * @namespace PIXI.CanvasTinter
  */
 var CanvasTinter = {};
 module.exports = CanvasTinter;


### PR DESCRIPTION
Also see pixijs/pixi-typescript#60

Relevant code: 

``` JavaScript
/**
 * Utility methods for Sprite/Texture tinting.
 * @static
 * @class
 * @memberof PIXI
 */
var CanvasTinter = {};
```

CanvasTinter is a plain object, meaning that `new PIXI.CanvasTinter()` will crash. 
But the JSDoc, and the documentation states that it is a class. which is wrong. 
